### PR TITLE
fix(django): add error when trying to insert binary data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,14 @@ services:
       - .:/python
     working_dir: /python
     depends_on:
-      - db
+      db:
+        condition: service_healthy
   db:
     image: postgres:10
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     environment:
       - POSTGRES_PASSWORD=postgres

--- a/tests/test_bulk_insert_models.py
+++ b/tests/test_bulk_insert_models.py
@@ -168,3 +168,17 @@ class E2ETestBulkInsertModelsTest(TestCase):
                 unsaved_model_with_pk,
                 unsaved_model_without_pk
             ])
+
+    def test_errors_when_uploading_binary(self):
+        unsaved_model1 = TestComplexModel(
+            binary_field=b"hello2",
+        )
+        unsaved_model2 = TestComplexModel(
+            binary_field=b"hello2",
+        )
+
+        with self.assertRaises(ValueError):
+            bulk_insert_models([
+                unsaved_model1,
+                unsaved_model2
+            ])

--- a/tests/test_project/models.py
+++ b/tests/test_project/models.py
@@ -14,6 +14,7 @@ class TestComplexModel(models.Model):
     test_foreign = models.ForeignKey(
         TestForeignKeyModel, on_delete=models.PROTECT, null=True
     )
+    binary_field = models.BinaryField(null=True)
 
 
 


### PR DESCRIPTION
## Summary
This library doesn't support uploading binary data. It incorrectly serializes the data and results in invalid data being inserted. This can eventually be fixed by using psycopg 3 with Django 4 and using the binary copy instead of the CSV format. 

For now, just error so we don't corrupt data

## Test Plan
##### How can reviewers test your change manually?
Check that it throws an error on binary data
##### What automated tests did you add? If none, please state why.
Added test for error

## Security Impact
Please answer the questions below about your PR. 
If yes, please explain and add `cedar-team/security` as reviewers.

##### Add/modify authentication, authorization, encryption, or HTTP headers?
No
##### Add/modify any PII or PHI data fields?
No
##### Add new third parties the app interacts with (e.g., Nordis/Stripe)?
No
##### Ask patients to enter a new kind of data, (e.g. insurance capture)?
No
##### Impact any of the other [Security Engineering Practices](https://careportal.atlassian.net/wiki/spaces/SEC/pages/1192690295/Security+Engineering+Practices)?
_Protect sensitive data, Validate your inputs, Know your user, Establish trust boundaries, Keep good records, Expect vulnerabilities, Follow least privilege_

No
