### PR TITLE
feat: add custom where clause in bulk_update_models and bulk_upsert_models

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ bulk_upsert_models(
     insert_only_field_names: Sequence[str] = None,
     model_changed_field_names: Sequence[str] = None,
     update_if_null_field_names: Sequence[str] = None,
+    update_where: Callable[[Sequence[Field], str, str], Composable] = None,
     return_models: bool = False,
 )
 ```
@@ -141,6 +142,7 @@ bulk_update_models(
     pk_field_names: Sequence[str] = None,
     model_changed_field_names: Sequence[str] = None,
     update_if_null_field_names: Sequence[str] = None,
+    update_where: Callable[[Sequence[Field], str, str], Composable] = None,
     return_models: bool = False,
 )
 ```
@@ -175,6 +177,7 @@ bulk_select_model_dicts(
     filter_field_names: Iterable[str],
     select_field_names: Iterable[str],
     filter_data: Iterable[Sequence],
+    select_for_update=False,
     skip_filter_transform=False,
 )
 ```

--- a/django_bulk_load/__init__.py
+++ b/django_bulk_load/__init__.py
@@ -7,6 +7,11 @@ from .bulk_load import (
     bulk_upsert_models,
 )
 
+from .queries import (
+    generate_distinct_condition,
+    generate_greater_than_condition
+)
+
 __all__ = [
     "bulk_select_model_dicts",
     "bulk_insert_models",
@@ -14,4 +19,6 @@ __all__ = [
     "bulk_upsert_models",
     "bulk_insert_changed_models",
     "bulk_load_models_with_queries",
+    "generate_distinct_condition",
+    "generate_greater_than_condition"
 ]

--- a/tests/test_bulk_update_models.py
+++ b/tests/test_bulk_update_models.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 from django.test import TestCase
-from django_bulk_load import bulk_update_models
+from django_bulk_load import bulk_update_models, generate_greater_than_condition
 from .test_project.models import (
     TestComplexModel,
     TestForeignKeyModel,
@@ -328,3 +328,47 @@ class E2ETestBulkUpdateModels(TestCase):
         self.assertIsNone(saved_model2.string_field)
         self.assertEqual(saved_model3.string_field, "d")
         self.assertIsNone(saved_model3.datetime_field)
+
+    def test_custom_where(self):
+        # Should only update integer_field and datetime_field
+        model1 = TestComplexModel(
+            integer_field=1,
+            string_field="a",
+        )
+        model1.save()
+        model1.integer_field = 5
+        model1.string_field = "b"
+
+        model2 = TestComplexModel(
+            integer_field=3, string_field="c"
+        )
+        model2.save()
+        model2.integer_field = 2
+        model2.string_field = "c"
+
+
+        def update_where(fields, source_table_name, destination_table_name):
+            """
+            Custom where clause where the new value must be greater than the old value
+            """
+
+            # This should only update if the new value is greater than previous value
+            return generate_greater_than_condition(
+                source_table_name=source_table_name,
+                destination_table_name=destination_table_name,
+                field=TestComplexModel._meta.get_field("integer_field"),
+            )
+
+        bulk_update_models(
+            [model1, model2],
+            update_field_names=["integer_field", "string_field"],
+            update_where=update_where
+        )
+
+        # First model should be updated because 5 > 1
+        saved_model1 = TestComplexModel.objects.get(integer_field=5)
+        self.assertEqual(saved_model1.string_field, "b")
+
+        # Second model should not be updated because 2 <  3
+        saved_model2 = TestComplexModel.objects.get(integer_field=3)
+        self.assertEqual(saved_model2.string_field, "c")


### PR DESCRIPTION
## Summary
Ticket: https://cedar-jira.atlassian.net/browse/CED-67122
This adds the ability to specify a custom `WHERE` clause when updating models in bulk. This is necessary to check revision numbers or last_updated dates before updating 

## Test Plan
##### How can reviewers test your change manually?
Check the new tests. You can use the new param called `update_where`
##### What automated tests did you add? If none, please state why.
Yes, updated tests for new argument and all existing tests still pass

## Security Impact
Please answer the questions below about your PR. 
If yes, please explain and add `cedar-team/security` as reviewers.

##### Add/modify authentication, authorization, encryption, or HTTP headers?
No
##### Add/modify any PII or PHI data fields?
No
##### Add new third parties the app interacts with (e.g., Nordis/Stripe)?
No
##### Ask patients to enter a new kind of data, (e.g. insurance capture)?
No
##### Impact any of the other [Security Engineering Practices](https://careportal.atlassian.net/wiki/spaces/SEC/pages/1192690295/Security+Engineering+Practices)?
_Protect sensitive data, Validate your inputs, Know your user, Establish trust boundaries, Keep good records, Expect vulnerabilities, Follow least privilege_

No
