### PR TITLE
Enable huge 'select' statements

### DIFF
--- a/django_bulk_load/bulk_load.py
+++ b/django_bulk_load/bulk_load.py
@@ -28,7 +28,6 @@ from .queries import (
     generate_select_query,
     generate_distinct_select_query,
     generate_update_query,
-    generate_values_select_query,
     copy_query
 )
 from .utils import generate_table_name

--- a/django_bulk_load/bulk_load.py
+++ b/django_bulk_load/bulk_load.py
@@ -9,7 +9,6 @@ from django.db.models import AutoField, Model, Field
 from psycopg2.sql import Composable, SQL
 
 from .django import (
-    django_field_to_query_value,
     get_fields_and_names,
     get_fields_from_names,
     get_model_fields,

--- a/django_bulk_load/bulk_load.py
+++ b/django_bulk_load/bulk_load.py
@@ -537,7 +537,15 @@ def bulk_select_model_dicts(
 
     with connection.cursor() as cursor:
         models = [model_class(**dict(zip(filter_field_names, x))) for x in filter_data]
-        cursor.execute(generate_select_query(table_name, create_temp_table_and_load(models, connection, cursor, filter_field_names), filter_fields, select_fields, for_update=select_for_update))
+        cursor.execute(
+                generate_select_query(
+                    table_name,
+                    create_temp_table_and_load(models, connection, cursor, filter_field_names),
+                    filter_fields,
+                    select_fields,
+                    for_update=select_for_update
+                    )
+                )
 
         logger.info(
             "Starting selecting models",

--- a/django_bulk_load/bulk_load.py
+++ b/django_bulk_load/bulk_load.py
@@ -537,7 +537,7 @@ def bulk_select_model_dicts(
     db_name = router.db_for_read(model_class)
     connection = connections[db_name]
 
-    with connection.cursor() as cursor:
+    with connection.cursor() as cursor, transaction.atomic(using=db_name):
         models = [model_class(**dict(zip(filter_field_names, x))) for x in filter_data]
         cursor.execute(
                 generate_distinct_select_query(

--- a/django_bulk_load/bulk_load.py
+++ b/django_bulk_load/bulk_load.py
@@ -26,6 +26,7 @@ from .queries import (
     generate_insert_for_update_query,
     generate_select_latest,
     generate_select_query,
+    generate_distinct_select_query,
     generate_update_query,
     generate_values_select_query,
     copy_query
@@ -96,6 +97,10 @@ def bulk_load_models_with_queries(
     field_names: Sequence[str] = None,
     return_models: bool = False,
 ):
+    """"
+    This could be called, "bulk-load-models-into-temp-table AND THEN execute queries"
+    Or, perhaps "execute_queries_with_temp_table_as_helper".
+    """
     start_time = monotonic()
     model = models[0]
     db_name = router.db_for_write(model.__class__)
@@ -538,7 +543,7 @@ def bulk_select_model_dicts(
     with connection.cursor() as cursor:
         models = [model_class(**dict(zip(filter_field_names, x))) for x in filter_data]
         cursor.execute(
-                generate_select_query(
+                generate_distinct_select_query(
                     table_name,
                     create_temp_table_and_load(models, connection, cursor, filter_field_names),
                     filter_fields,

--- a/django_bulk_load/bulk_load.py
+++ b/django_bulk_load/bulk_load.py
@@ -6,7 +6,6 @@ from django.db import connections, router, transaction
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.utils import CursorWrapper
 from django.db.models import AutoField, Model, Field
-from psycopg2.extras import execute_values
 from psycopg2.sql import Composable, SQL
 
 from .django import (

--- a/django_bulk_load/queries.py
+++ b/django_bulk_load/queries.py
@@ -307,6 +307,7 @@ def generate_select_query(
     loading_table_name: str,
     join_fields: Sequence[models.Field],
     select_fields: Sequence[models.Field] = None,
+    for_update=False
 ) -> Composable:
     join_clause = generate_join_condition(
         source_table_name=loading_table_name,
@@ -326,14 +327,24 @@ def generate_select_query(
     else:
         fields = SQL("{table_name}.*").format(table_name=Identifier(table_name))
 
-    return SQL(
-        "SELECT {fields} FROM {table_name} INNER JOIN {loading_table_name} ON {join_clause}"
-    ).format(
-        loading_table_name=Identifier(loading_table_name),
-        join_clause=join_clause,
-        fields=fields,
-        table_name=Identifier(table_name),
-    )
+    if for_update:
+        return SQL(
+            "SELECT {fields} FROM {table_name} INNER JOIN {loading_table_name} ON {join_clause} FOR UPDATE"
+        ).format(
+            loading_table_name=Identifier(loading_table_name),
+            join_clause=join_clause,
+            fields=fields,
+            table_name=Identifier(table_name),
+        )
+    else:
+        return SQL(
+            "SELECT {fields} FROM {table_name} INNER JOIN {loading_table_name} ON {join_clause}"
+        ).format(
+            loading_table_name=Identifier(loading_table_name),
+            join_clause=join_clause,
+            fields=fields,
+            table_name=Identifier(table_name),
+        )
 
 
 def generate_values_select_query(

--- a/django_bulk_load/queries.py
+++ b/django_bulk_load/queries.py
@@ -327,25 +327,18 @@ def generate_distinct_select_query(
     else:
         fields = SQL("{table_name}.*").format(table_name=Identifier(table_name))
 
-    if for_update:
-        return SQL(
-            "SELECT {fields} FROM {table_name} where exists (select 1 from {loading_table_name} where {join_clause}) FOR UPDATE"
-        ).format(
-            loading_table_name=Identifier(loading_table_name),
-            join_clause=join_clause,
-            fields=fields,
-            table_name=Identifier(table_name),
-        )
-    else:
-        return SQL(
-            "SELECT {fields} FROM {table_name} where exists (select 1 from {loading_table_name} where {join_clause})"
-        ).format(
-            loading_table_name=Identifier(loading_table_name),
-            join_clause=join_clause,
-            fields=fields,
-            table_name=Identifier(table_name),
-        )
+    base_query = SQL(
+        "SELECT {fields} FROM {table_name} where exists (select 1 from {loading_table_name} where {join_clause})"
+    ).format(
+        loading_table_name=Identifier(loading_table_name),
+        join_clause=join_clause,
+        fields=fields,
+        table_name=Identifier(table_name),
+    )
 
+    if for_update:
+        return Composed([base_query, SQL("FOR UPDATE")])
+    return base_query
 
 
 

--- a/django_bulk_load/queries.py
+++ b/django_bulk_load/queries.py
@@ -382,30 +382,3 @@ def generate_select_query(
         table_name=Identifier(table_name),
     )
 
-
-def generate_values_select_query(
-    table_name: str,
-    filter_fields: Sequence[models.Field],
-    select_fields: Sequence[models.Field],
-    select_for_update: bool
-):
-    select_fields_sql = SQL(", ").join(
-        [Identifier(field.column) for field in select_fields]
-    )
-
-    filter_fields_sql = SQL(", ").join(
-        [Identifier(field.column) for field in filter_fields]
-    )
-
-    for_update = SQL("")
-    if select_for_update:
-        for_update = SQL(" FOR UPDATE")
-
-    return SQL(
-        "SELECT {select_fields_sql} from {table_name} where ({filter_fields_sql}) IN (VALUES %s){for_update}"
-    ).format(
-        table_name=Identifier(table_name),
-        select_fields_sql=select_fields_sql,
-        filter_fields_sql=filter_fields_sql,
-        for_update=for_update,
-    )

--- a/tests/test_bulk_select_model_dicts.py
+++ b/tests/test_bulk_select_model_dicts.py
@@ -21,6 +21,41 @@ class E2ETestBulkSelectModelDicts(TestCase):
             [],
         )
 
+    def test_ignores_duplicates_in_input(self):
+        saved_model = TestComplexModel(
+            integer_field=123,
+            string_field="hello",
+        )
+        saved_model.save()
+        result_dicts = bulk_select_model_dicts(
+            model_class=TestComplexModel,
+            filter_field_names=["integer_field"],
+            filter_data=[(123,), (123,)],
+            select_field_names=["string_field", "integer_field"],
+        )
+
+        self.assertEqual(len(result_dicts), 1)
+
+    def test_finds_duplicates_when_they_exist(self):
+        TestComplexModel(
+            integer_field=123,
+            string_field="hello",
+        ).save()
+        secod_saved_model = TestComplexModel(
+            integer_field=123,
+            string_field="hello",
+        ).save()
+        result_dicts = bulk_select_model_dicts(
+            model_class=TestComplexModel,
+            filter_field_names=["integer_field"],
+            filter_data=[(123,), (123,)],
+            select_field_names=["string_field", "integer_field"],
+        )
+
+        self.assertEqual(len(result_dicts), 2)
+
+
+
     def test_single_select(self):
         foreign = TestForeignKeyModel()
         foreign.save()


### PR DESCRIPTION
## Summary
Use temp-tables to enable us to pass in a million IDs for a given 'select' statement

In postgres, there is some limit to how long you can make a `select * from table where id in (1,2,3,4,5.....)` statement.

But at Cedar, we sometimes have really big files which come from third parties.  And such a file may contain a list of millions of IDs.  And we may want to select our data out of the database, based on these millions of incoming IDs.  This feature enables us to do this.

There are lots of existing helper methods that allow us to implement this.  The general approach is: 
* use the existing machinery to create a temp-table containing the data that we care about.  
* join this temp-table against the real table, in order to pull data from the real table

## Test Plan
##### How can reviewers test your change manually?
Tinker with the automated tests that are part of this PR

##### What automated tests did you add? If none, please state why.
I wanted to rely just on the existing tests, since I viewed this change as being simply about implementation details.  Then I realized that my first attempt was actually broken in a way that was not reflected by the tests.  The problem is that you can get extra records back, if your `filter_data` contains duplicates.  So I had to write tests that illustrated this potential problem.

## Security Impact
Please answer the questions below about your PR. 
If yes, please explain and add `cedar-team/security` as reviewers.

##### Add/modify authentication, authorization, encryption, or HTTP headers?
No
##### Add/modify any PII or PHI data fields?
No
##### Add new third parties the app interacts with (e.g., Nordis/Stripe)?
No
##### Ask patients to enter a new kind of data, (e.g. insurance capture)?
No
##### Impact any of the other [Security Engineering Practices]
No