### PR TITLE
CED-69517: Improve bulk_select_model_dicts performance for slow USACS CustomerPhoneNumber query

### DIFF
--- a/django_bulk_load/django.py
+++ b/django_bulk_load/django.py
@@ -59,6 +59,27 @@ def _default_model_to_value(model, field, connection):
     return field.get_db_prep_save(field_val, connection=connection)
 
 
+def raw_data_to_tsv_buffer(raw_data: Iterable[Iterable[Any]]) -> StringIO:
+    """
+    Convert raw data (sequences of values) to TSV buffer for COPY operations.
+    
+    :param raw_data: Iterable of sequences containing raw values
+    :return: StringIO buffer containing TSV data
+    """
+    buffer = StringIO()
+    tsv_writer = csv.writer(buffer, delimiter="\t", lineterminator="\n")
+    for row in raw_data:
+        processed_row = []
+        for val in row:
+            if val is None:
+                processed_row.append(NULL_CHARACTER)
+            else:
+                processed_row.append(str(val))
+        tsv_writer.writerow(processed_row)
+    buffer.seek(0)
+    return buffer
+
+
 def models_to_tsv_buffer(
     models: Iterable[Any],
     include_fields: Iterable[models.Field],


### PR DESCRIPTION
## Summary

MOVED TO https://github.com/cedar-team/cedar/pull/57998

In the current implementation of `bulk_select_model_dicts`, we are using `generate_values_select_query`, which generates a multi-column `SELECT {} from {} where {} IN (VALUES ...) `query.
This query is particularly slow for the USACS pull because of USACS's large volume of customer data.

We should utilize a temp table instead of the large IN (VALUES ...) clause.

[Querying CustomerPhoneNumbers for contact capture logic](https://github.com/cedar-team/cedar/blob/c7212d64b7362cf816ff195b89f11b9895e7116c/integrations/integrations/etls/user_identity_and_contact_info/user_infos.py#L996) seems to be especially slow, but I think we can apply these updates to emails and postal addresses as well. 

NOTE: These changes will move to the monolith once this PR gets merged: https://github.com/cedar-team/cedar/pull/57913.
I'm creating a draft PR here to get feedback while I test locally.

## Test Plan
##### How can reviewers test your change manually?
I'm working on testing changes with a local USACS sync.
##### What automated tests did you add? If none, please state why.
WIP

## Security Impact
Please answer the questions below about your PR. 
If yes, please explain and add `cedar-team/security` as reviewers.

##### Add/modify authentication, authorization, encryption, or HTTP headers?
Yes/No
##### Add/modify any PII or PHI data fields?
Yes/No
##### Add new third parties the app interacts with (e.g., Nordis/Stripe)?
Yes/No
##### Ask patients to enter a new kind of data, (e.g. insurance capture)?
Yes/No
##### Impact any of the other [Security Engineering Practices](https://careportal.atlassian.net/wiki/spaces/SEC/pages/1192690295/Security+Engineering+Practices)?
_Protect sensitive data, Validate your inputs, Know your user, Establish trust boundaries, Keep good records, Expect vulnerabilities, Follow least privilege_

Yes/No
